### PR TITLE
Consolidate publishing to maven central experience using io.github.gradle-nexus:publish-plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,9 +35,7 @@ contacts {
 }
 
 dependencies {
-    implementation("de.marcphilipp.gradle:nexus-publish-plugin:0.4.0")
-    implementation("io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0")
-    testImplementation("io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0")
+    implementation("io.github.gradle-nexus:publish-plugin:1.0.0")
     constraints {
         val kotlinVersion by extra("1.4.30")
         implementation("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,10 +1,7 @@
 {
     "compileClasspath": {
-        "de.marcphilipp.gradle:nexus-publish-plugin": {
-            "locked": "0.4.0"
-        },
-        "io.codearte.gradle.nexus:gradle-nexus-staging-plugin": {
-            "locked": "0.22.0"
+        "io.github.gradle-nexus:publish-plugin": {
+            "locked": "1.0.0"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.4.30"
@@ -30,11 +27,8 @@
         }
     },
     "implementationDependenciesMetadata": {
-        "de.marcphilipp.gradle:nexus-publish-plugin": {
-            "locked": "0.4.0"
-        },
-        "io.codearte.gradle.nexus:gradle-nexus-staging-plugin": {
-            "locked": "0.22.0"
+        "io.github.gradle-nexus:publish-plugin": {
+            "locked": "1.0.0"
         }
     },
     "integTestApiDependenciesMetadata": {
@@ -46,11 +40,8 @@
         "com.netflix.nebula:nebula-test": {
             "locked": "7.10.2"
         },
-        "de.marcphilipp.gradle:nexus-publish-plugin": {
-            "locked": "0.4.0"
-        },
-        "io.codearte.gradle.nexus:gradle-nexus-staging-plugin": {
-            "locked": "0.22.0"
+        "io.github.gradle-nexus:publish-plugin": {
+            "locked": "1.0.0"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.4.30"
@@ -68,11 +59,8 @@
         "com.netflix.nebula:nebula-test": {
             "locked": "7.10.2"
         },
-        "de.marcphilipp.gradle:nexus-publish-plugin": {
-            "locked": "0.4.0"
-        },
-        "io.codearte.gradle.nexus:gradle-nexus-staging-plugin": {
-            "locked": "0.22.0"
+        "io.github.gradle-nexus:publish-plugin": {
+            "locked": "1.0.0"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.4.30"
@@ -110,22 +98,16 @@
         }
     },
     "runtimeClasspath": {
-        "de.marcphilipp.gradle:nexus-publish-plugin": {
-            "locked": "0.4.0"
-        },
-        "io.codearte.gradle.nexus:gradle-nexus-staging-plugin": {
-            "locked": "0.22.0"
+        "io.github.gradle-nexus:publish-plugin": {
+            "locked": "1.0.0"
         }
     },
     "testCompileClasspath": {
         "com.netflix.nebula:nebula-test": {
             "locked": "7.10.2"
         },
-        "de.marcphilipp.gradle:nexus-publish-plugin": {
-            "locked": "0.4.0"
-        },
-        "io.codearte.gradle.nexus:gradle-nexus-staging-plugin": {
-            "locked": "0.22.0"
+        "io.github.gradle-nexus:publish-plugin": {
+            "locked": "1.0.0"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.4.30"
@@ -138,11 +120,8 @@
         "com.netflix.nebula:nebula-test": {
             "locked": "7.10.2"
         },
-        "de.marcphilipp.gradle:nexus-publish-plugin": {
-            "locked": "0.4.0"
-        },
-        "io.codearte.gradle.nexus:gradle-nexus-staging-plugin": {
-            "locked": "0.22.0"
+        "io.github.gradle-nexus:publish-plugin": {
+            "locked": "1.0.0"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.4.30"
@@ -155,11 +134,8 @@
         "com.netflix.nebula:nebula-test": {
             "locked": "7.10.2"
         },
-        "de.marcphilipp.gradle:nexus-publish-plugin": {
-            "locked": "0.4.0"
-        },
-        "io.codearte.gradle.nexus:gradle-nexus-staging-plugin": {
-            "locked": "0.22.0"
+        "io.github.gradle-nexus:publish-plugin": {
+            "locked": "1.0.0"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.4.30"

--- a/src/main/kotlin/nebula/plugin/publishing/MavenCentralPublishingPlugin.kt
+++ b/src/main/kotlin/nebula/plugin/publishing/MavenCentralPublishingPlugin.kt
@@ -15,47 +15,42 @@
  */
 package nebula.plugin.publishing
 
-import de.marcphilipp.gradle.nexus.InitializeNexusStagingRepository
-import de.marcphilipp.gradle.nexus.NexusPublishExtension
-import de.marcphilipp.gradle.nexus.NexusRepository
-import io.codearte.gradle.nexus.NexusStagingExtension
-import io.codearte.gradle.nexus.NexusStagingPlugin
+import io.github.gradlenexus.publishplugin.NexusPublishExtension
+import io.github.gradlenexus.publishplugin.NexusPublishPlugin
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository
-import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
-import org.gradle.api.publish.plugins.PublishingPlugin
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.*
 import java.net.URI
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Configures publication to staging repo in sonatype and makes sure staging repositories are closed/released
  */
 class MavenCentralPublishingPlugin : Plugin<Project> {
     companion object {
-        private val serverUrlToStagingRepoUrl = ConcurrentHashMap<URI, URI>()
-        const val closeAndPromoteRepositoryTaskName = "closeAndReleaseRepository"
+        const val closeAndPromoteRepositoryTaskName = "closeAndReleaseSonatypeStagingRepository"
         const val sonatypeOssRepositoryUrl = "https://oss.sonatype.org/service/local/"
-        const val nexusStagingPluginId = "io.codearte.nexus-staging"
         const val nebulaMavenPublishPluginId = "nebula.maven-publish"
     }
 
     override fun apply(project: Project) {
+        if (project.rootProject != project) {
+            return
+        }
+
         if (!isFinalRelease(project)) {
             return
         }
 
-        if (project.rootProject == project) {
-            project.pluginManager.apply(NexusStagingPlugin::class)
-        }
+        project.pluginManager.apply(NexusPublishPlugin::class)
 
         val nebulaOssPublishingExtension = project.rootProject.extensions.findByType(NebulaOssPublishingExtension::class.java) ?: project.rootProject.extensions.create("nebulaOssPublishing", NebulaOssPublishingExtension::class.java)
 
-        val nexusPublishExtension = project.extensions.create<NexusPublishExtension>("nexusPublishExtension", project)
+        val nexusPublishExtension = project.extensions.findByType(NexusPublishExtension::class)
+        if(nexusPublishExtension == null) {
+            throw GradleException("Could not find registered NexusPublishExtension")
+        }
         nexusPublishExtension.packageGroup.set(nebulaOssPublishingExtension.packageGroup.get())
         nexusPublishExtension.repositories.sonatype {
             nexusUrl.set(URI(sonatypeOssRepositoryUrl))
@@ -64,79 +59,24 @@ class MavenCentralPublishingPlugin : Plugin<Project> {
             stagingProfileId.set(nebulaOssPublishingExtension.stagingProfileId.orNull)
         }
 
-        nexusPublishExtension.repositories.all {
-            project.tasks.register("publishTo${name.capitalize()}") {
-                description = "Publishes all Maven publications produced by this project to the '${this@all.name}' Nexus repository."
-                group = PublishingPlugin.PUBLISH_TASK_GROUP
-            }
-            project.tasks
-                .register<InitializeNexusStagingRepository>("initialize${name.capitalize()}StagingRepository", project.objects, nexusPublishExtension, this,
-                    serverUrlToStagingRepoUrl
-                )
-        }
-        nexusPublishExtension.repositories.whenObjectRemoved {
-            project.tasks.remove(project.tasks.named("publishTo${name.capitalize()}") as Any)
-            project.tasks.remove(project.tasks.named("initialize${name.capitalize()}StagingRepository") as Any)
-        }
-
-        project.afterEvaluate {
-            val nexusRepositories = addMavenRepositories(project, nexusPublishExtension)
-            nexusRepositories.forEach { (nexusRepo, mavenRepo) ->
-                val publishToNexusTask = project.tasks.named("publishTo${nexusRepo.name.capitalize()}")
-                val initializeTask = project.tasks.withType(InitializeNexusStagingRepository::class)
-                    .named("initialize${nexusRepo.name.capitalize()}StagingRepository")
-                configureTaskDependencies(project, publishToNexusTask, initializeTask, mavenRepo)
-            }
-        }
-
-        project.rootProject.plugins.withId(nexusStagingPluginId) {
-            val nexusStagingExtension = project.rootProject.the<NexusStagingExtension>()
-            nexusStagingExtension.username = nebulaOssPublishingExtension.sonatypeUsername.get()
-            nexusStagingExtension.password = nebulaOssPublishingExtension.sonatypePassword.get()
-            nexusStagingExtension.packageGroup = nebulaOssPublishingExtension.packageGroup.get()
-            nexusStagingExtension.stagingProfileId = nebulaOssPublishingExtension.stagingProfileId.orNull
-        }
-
         project.afterEvaluate {
             project.plugins.withId(nebulaMavenPublishPluginId) {
                 project.rootProject.tasks.named("postRelease").configure {
-                    this.dependsOn(project.tasks.withType(PublishToMavenRepository::class.java))
+                    project.subprojects.forEach { subproject ->
+                        this.dependsOn(subproject.tasks.withType(PublishToMavenRepository::class.java))
+                    }
                 }
             }
 
-            project.rootProject.plugins.withId(nexusStagingPluginId) {
+            project.rootProject.plugins.withType(NexusPublishPlugin::class) {
                 project.rootProject.tasks.named("postRelease").configure {
                     this.dependsOn(project.rootProject.tasks.named(closeAndPromoteRepositoryTaskName))
-                    this.mustRunAfter(project.tasks.withType(PublishToMavenRepository::class.java))
+                    project.subprojects.forEach { subproject ->
+                        project.subprojects.forEach { subproject ->
+                            this.mustRunAfter(subproject.tasks.withType(PublishToMavenRepository::class.java))
+                        }
+                    }
                 }
-            }
-        }
-    }
-
-
-    private fun addMavenRepositories(project: Project, extension: NexusPublishExtension): Map<NexusRepository, MavenArtifactRepository> {
-        return extension.repositories.associateWith { nexusRepo ->
-            project.the<PublishingExtension>().repositories.maven {
-                name = nexusRepo.name
-                url = nexusRepo.nexusUrl.get()
-                credentials {
-                    username = nexusRepo.username.orNull
-                    password = nexusRepo.password.orNull
-                }
-            }
-        }
-    }
-
-    private fun configureTaskDependencies(project: Project, publishToNexusTask: TaskProvider<Task>, initializeTask: TaskProvider<InitializeNexusStagingRepository>, nexusRepository: MavenArtifactRepository) {
-        val publishTasks = project.tasks
-            .withType<PublishToMavenRepository>()
-            .matching { it.repository == nexusRepository }
-        publishToNexusTask.configure { dependsOn(publishTasks) }
-        // PublishToMavenRepository tasks may not yet have been initialized
-        project.afterEvaluate {
-            publishTasks.configureEach {
-                dependsOn(initializeTask)
-                doFirst { logger.info("Uploading to {}", repository.url) }
             }
         }
     }

--- a/src/main/kotlin/nebula/plugin/publishing/NebulaOssRepositoriesPlugin.kt
+++ b/src/main/kotlin/nebula/plugin/publishing/NebulaOssRepositoriesPlugin.kt
@@ -18,6 +18,7 @@ package nebula.plugin.publishing
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.kotlin.dsl.configure
 import org.gradle.util.GradleVersion
 


### PR DESCRIPTION
Consolidates experience by using the new https://github.com/gradle-nexus/publish-plugin/ 