### PR TITLE
Introduce gradle task to validate POM before publishing to maven central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ contacts {
 
 dependencies {
     implementation("io.github.gradle-nexus:publish-plugin:1.0.0")
+    implementation("org.apache.maven:maven-model:3.6.2")
     constraints {
         val kotlinVersion by extra("1.4.30")
         implementation("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -3,6 +3,9 @@
         "io.github.gradle-nexus:publish-plugin": {
             "locked": "1.0.0"
         },
+        "org.apache.maven:maven-model": {
+            "locked": "3.6.2"
+        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.4.30"
         },
@@ -29,6 +32,9 @@
     "implementationDependenciesMetadata": {
         "io.github.gradle-nexus:publish-plugin": {
             "locked": "1.0.0"
+        },
+        "org.apache.maven:maven-model": {
+            "locked": "3.6.2"
         }
     },
     "integTestApiDependenciesMetadata": {
@@ -42,6 +48,9 @@
         },
         "io.github.gradle-nexus:publish-plugin": {
             "locked": "1.0.0"
+        },
+        "org.apache.maven:maven-model": {
+            "locked": "3.6.2"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.4.30"
@@ -61,6 +70,9 @@
         },
         "io.github.gradle-nexus:publish-plugin": {
             "locked": "1.0.0"
+        },
+        "org.apache.maven:maven-model": {
+            "locked": "3.6.2"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.4.30"
@@ -100,6 +112,9 @@
     "runtimeClasspath": {
         "io.github.gradle-nexus:publish-plugin": {
             "locked": "1.0.0"
+        },
+        "org.apache.maven:maven-model": {
+            "locked": "3.6.2"
         }
     },
     "testCompileClasspath": {
@@ -108,6 +123,9 @@
         },
         "io.github.gradle-nexus:publish-plugin": {
             "locked": "1.0.0"
+        },
+        "org.apache.maven:maven-model": {
+            "locked": "3.6.2"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.4.30"
@@ -123,6 +141,9 @@
         "io.github.gradle-nexus:publish-plugin": {
             "locked": "1.0.0"
         },
+        "org.apache.maven:maven-model": {
+            "locked": "3.6.2"
+        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.4.30"
         },
@@ -136,6 +157,9 @@
         },
         "io.github.gradle-nexus:publish-plugin": {
             "locked": "1.0.0"
+        },
+        "org.apache.maven:maven-model": {
+            "locked": "3.6.2"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.4.30"

--- a/src/main/kotlin/nebula/plugin/publishing/pom/MavenCentralPomVerificationException.kt
+++ b/src/main/kotlin/nebula/plugin/publishing/pom/MavenCentralPomVerificationException.kt
@@ -1,0 +1,8 @@
+package nebula.plugin.publishing.pom
+
+class MavenCentralPomVerificationException : Exception {
+    constructor() : super()
+    constructor(message: String) : super(message)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+    constructor(cause: Throwable) : super(cause)
+}

--- a/src/main/kotlin/nebula/plugin/publishing/pom/MavenCentralPomVerifier.kt
+++ b/src/main/kotlin/nebula/plugin/publishing/pom/MavenCentralPomVerifier.kt
@@ -1,0 +1,63 @@
+package nebula.plugin.publishing.pom
+
+import org.apache.maven.model.Model
+import org.gradle.api.GradleException
+
+/**
+ * Verifies if POM follows rules for Maven Central
+ * @see <a href="http://maven.apache.org/repository/guide-central-repository-upload.html">http://maven.apache.org/repository/guide-central-repository-upload.html</a>
+ */
+class MavenCentralPomVerifier {
+    companion object {
+
+        @JvmStatic
+        fun verify(model: Model) {
+            val errors = mutableListOf<String>()
+            if(model.groupId.isNullOrEmpty()) {
+                errors.add("<groupId> must not be null or blank")
+            }
+            if(model.artifactId.isNullOrEmpty()) {
+                errors.add("<artifactId> must not be null or blank")
+            }
+            if(model.version.isNullOrEmpty()) {
+                errors.add("<version> must not be null or blank. Please configure a valid version in your project")
+            }
+            if(model.description.isNullOrEmpty()) {
+                errors.add("<description> must not be null or blank. This information is added for you via nebula.netflixoss plugin")
+            }
+            if(model.url.isNullOrEmpty()) {
+                errors.add("<url> must not be null or blank. This information is added for you via nebula.netflixoss plugin")
+            }
+            if(model.scm?.url.isNullOrEmpty()) {
+                errors.add("<scm> url is required. This information is added for you via nebula.netflixoss plugin")
+            }
+            if(model.licenses.isEmpty()) {
+                errors.add("<licenses> are required. This information is added for you via nebula.netflixoss plugin")
+            }
+            model.licenses.forEachIndexed { index, license ->
+                if(license.name.isNullOrBlank()  || license.url.isNullOrBlank()) {
+                    errors.add("License $index must have <name> and <url>. This information is added for you via nebula.netflixoss plugin")
+                }
+            }
+            if(model.developers.isEmpty()) {
+                errors.add("<developers> are required. Please add this information using gradle-contacts-plugin (https://github.com/nebula-plugins/gradle-contacts-plugin)")
+            }
+            model.developers.forEachIndexed { index, developer ->
+                if(developer.name.isNullOrBlank() && developer.email.isNullOrBlank() && developer.id.isNullOrBlank()) {
+                    errors.add("Developer $index must have one of: <name>, <email> or <id>. Please add this information using gradle-contacts-plugin (https://github.com/nebula-plugins/gradle-contacts-plugin)")
+                }
+            }
+            model.dependencies.forEach { dependency ->
+                if(dependency.version.contains(".+")) {
+                    errors.add("Dependency ${dependency.groupId}:${dependency.artifactId}:${dependency.version} contains '.+'. This is an invalid dynamic version syntax.  Replace with a fixed version or standard mathematical notation e.g., [1.5,) for version 1.5 and higher. More info in https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN402")
+                }
+            }
+
+            if (errors.isNotEmpty()) {
+                throw MavenCentralPomVerificationException("POM verification for Maven Central failed.\n " +
+                        "POM contains the following errors: \n" +
+                        errors.joinToString(separator = "\n"))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/nebula/plugin/publishing/pom/PomParser.kt
+++ b/src/main/kotlin/nebula/plugin/publishing/pom/PomParser.kt
@@ -1,0 +1,21 @@
+package nebula.plugin.publishing.pom
+
+import org.apache.maven.model.Model
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader
+import java.io.File
+import java.io.FileReader
+
+class PomParser {
+    companion object {
+        private val reader = MavenXpp3Reader()
+
+        @JvmStatic
+        fun parse(pomFile: File): Model {
+            return try {
+                reader.read(FileReader(pomFile))
+            } catch (e: Exception) {
+                throw MavenCentralPomVerificationException("Error while trying to read nebula publication Pom file", e)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/nebula/plugin/publishing/pom/VerifyPomForMavenCentralTask.kt
+++ b/src/main/kotlin/nebula/plugin/publishing/pom/VerifyPomForMavenCentralTask.kt
@@ -1,0 +1,19 @@
+package nebula.plugin.publishing.pom
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
+
+open class VerifyPomForMavenCentralTask @Inject constructor(objects: ObjectFactory): DefaultTask() {
+    @InputFile
+    val pomFile: RegularFileProperty = objects.fileProperty()
+
+    @TaskAction
+    fun verifyPom() {
+        val model = PomParser.parse(pomFile.asFile.get())
+        MavenCentralPomVerifier.verify(model)
+    }
+}

--- a/src/test/groovy/nebula/plugin/publishing/pom/BasePomSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/pom/BasePomSpec.groovy
@@ -1,0 +1,9 @@
+package nebula.plugin.publishing.pom
+
+import spock.lang.Specification
+
+class BasePomSpec extends Specification {
+    File findPomFile(String pomPath) {
+        return new File(this.class.getResource(pomPath).toURI())
+    }
+}

--- a/src/test/groovy/nebula/plugin/publishing/pom/MavenCentralPomVerifierSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/pom/MavenCentralPomVerifierSpec.groovy
@@ -1,0 +1,78 @@
+package nebula.plugin.publishing.pom
+
+class MavenCentralPomVerifierSpec  extends BasePomSpec {
+    def 'POM file passes validation'() {
+        setup:
+        File pomFile = findPomFile("/my-module.pom")
+        def pom = PomParser.parse(pomFile)
+
+        when:
+        MavenCentralPomVerifier.verify(pom)
+
+        then:
+        notThrown(MavenCentralPomVerificationException)
+    }
+
+    def 'collect errors from pom validation'() {
+        setup:
+        File pomFile = findPomFile("/my-module-with-invalid-metadata.pom")
+        def pom = PomParser.parse(pomFile)
+
+        when:
+        MavenCentralPomVerifier.verify(pom)
+
+        then:
+        def ex = thrown(MavenCentralPomVerificationException)
+        ex.message.contains('POM verification for Maven Central failed')
+        ex.message.contains('<groupId> must not be null or blank')
+        ex.message.contains('<artifactId> must not be null or blank')
+        ex.message.contains('<version> must not be null or blank')
+        ex.message.contains('<description> must not be null or blank')
+        ex.message.contains('<url> must not be null or blank')
+        ex.message.contains('<scm> url is required')
+        ex.message.contains('<licenses> are required')
+        ex.message.contains('<developers> are required')
+    }
+
+    def 'collect errors from pom validation - invalid license'() {
+        setup:
+        File pomFile = findPomFile("/my-module-with-invalid-license.pom")
+        def pom = PomParser.parse(pomFile)
+
+        when:
+        MavenCentralPomVerifier.verify(pom)
+
+        then:
+        def ex = thrown(MavenCentralPomVerificationException)
+        ex.message.contains('POM verification for Maven Central failed')
+        ex.message.contains('License 0 must have <name> and <url>')
+    }
+
+    def 'collect errors from pom validation - invalid developer'() {
+        setup:
+        File pomFile = findPomFile("/my-module-with-invalid-developers.pom")
+        def pom = PomParser.parse(pomFile)
+
+        when:
+        MavenCentralPomVerifier.verify(pom)
+
+        then:
+        def ex = thrown(MavenCentralPomVerificationException)
+        ex.message.contains('POM verification for Maven Central failed')
+        ex.message.contains('Developer 0 must have one of: <name>, <email> or <id>')
+    }
+
+    def 'collect errors from pom validation - invalid version (dynamic range)'() {
+        setup:
+        File pomFile = findPomFile("/my-module-with-invalid-dynamic-range.pom")
+        def pom = PomParser.parse(pomFile)
+
+        when:
+        MavenCentralPomVerifier.verify(pom)
+
+        then:
+        def ex = thrown(MavenCentralPomVerificationException)
+        ex.message.contains('POM verification for Maven Central failed')
+        ex.message.contains('Dependency org.codehaus.groovy:groovy-all:2.5.+ contains \'.+\'. This is an invalid dynamic version syntax.  Replace with a fixed version or standard mathematical notation e.g., [1.5,) for version 1.5 and higher. More info in https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN402')
+    }
+}

--- a/src/test/groovy/nebula/plugin/publishing/pom/PomParserSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/pom/PomParserSpec.groovy
@@ -1,0 +1,48 @@
+package nebula.plugin.publishing.pom
+
+import spock.lang.Subject
+
+@Subject(PomParser)
+class PomParserSpec extends BasePomSpec {
+
+    def 'should parse valid POM file'() {
+        setup:
+        File pomFile = findPomFile("/my-module.pom")
+
+        when:
+        def model = PomParser.parse(pomFile)
+
+        then:
+        model.groupId == 'com.netflix.nebula'
+        model.artifactId == 'my-module'
+        model.version == '1.0.0'
+        model.description == 'my-module description'
+        model.url == 'https://github.com/nebula-plugins/my-module'
+        model.developers[0].name == 'Netflix Open Source Development'
+        model.developers[0].email == 'netflixoss@netflix.com'
+        model.scm.url == 'https://github.com/nebula-plugins/my-module.git'
+        model.licenses[0].name == 'The Apache Software License, Version 2.0'
+        model.licenses[0].url == 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+    }
+
+    def 'should fail if POM file is invalid'() {
+        setup:
+        File pomFile = findPomFile("/invalid.pom")
+
+        when:
+         PomParser.parse(pomFile)
+
+        then:
+        def ex = thrown(MavenCentralPomVerificationException)
+        ex.message.contains 'Error while trying to read nebula publication Pom file'
+    }
+
+    def 'should fail if POM file does not exist'() {
+        when:
+        PomParser.parse(new File("/this-does-not-exist.pom"))
+
+        then:
+        def ex = thrown(MavenCentralPomVerificationException)
+        ex.message.contains 'Error while trying to read nebula publication Pom file'
+    }
+}

--- a/src/test/resources/invalid.pom
+++ b/src/test/resources/invalid.pom
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId></groupId>
+    <artifactId>my-module</artifactId>
+    <version>
+</project>

--- a/src/test/resources/my-module-with-invalid-developers.pom
+++ b/src/test/resources/my-module-with-invalid-developers.pom
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.netflix.nebula</groupId>
+    <artifactId>my-module</artifactId>
+    <version>1.0.0</version>
+    <name>my-module</name>
+    <description>my-module description</description>
+    <url>https://github.com/nebula-plugins/my-module</url>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+        </developer>
+    </developers>
+    <scm>
+        <url>https://github.com/nebula-plugins/my-module.git</url>
+    </scm>
+    <dependencies>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.5.7</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <properties>
+        <nebula_Manifest_Version>1.0</nebula_Manifest_Version>
+        <nebula_Implementation_Title>com.netflix.nebula#my-module;1.0.0</nebula_Implementation_Title>
+        <nebula_Implementation_Version>1.8.0</nebula_Implementation_Version>
+        <nebula_Built_Status>integration</nebula_Built_Status>
+        <nebula_Built_By>travis</nebula_Built_By>
+        <nebula_Built_OS>Linux</nebula_Built_OS>
+        <nebula_Build_Date>2019-11-21_21:30:10</nebula_Build_Date>
+        <nebula_Gradle_Version>5.6.2</nebula_Gradle_Version>
+        <nebula_Module_Owner>netflixoss@netflix.com</nebula_Module_Owner>
+        <nebula_Module_Email>netflixoss@netflix.com</nebula_Module_Email>
+        <nebula_Module_Origin>https://github.com/nebula-plugins/my-module.git</nebula_Module_Origin>
+        <nebula_Change>b5e55af</nebula_Change>
+        <nebula_Branch>b5e55af8921fa1abe3345ca09c7acaefd8b50968</nebula_Branch>
+        <nebula_Build_Host>travis-job-3fcfc919-7e06-4960-98cb-a538a09f08c3</nebula_Build_Host>
+        <nebula_Build_Job>nebula-plugins/my-module</nebula_Build_Job>
+        <nebula_Build_Number>23</nebula_Build_Number>
+        <nebula_Build_Id>615268376</nebula_Build_Id>
+        <nebula_Created_By>1.8.0_222-8u222-b10-1ubuntu1~16.04.1-b10 (Private Build)</nebula_Created_By>
+        <nebula_Build_Java_Version>1.8.0_222</nebula_Build_Java_Version>
+        <nebula_X_Compile_Target_JDK>1.8</nebula_X_Compile_Target_JDK>
+        <nebula_X_Compile_Source_JDK>1.8</nebula_X_Compile_Source_JDK>
+    </properties>
+</project>

--- a/src/test/resources/my-module-with-invalid-dynamic-range.pom
+++ b/src/test/resources/my-module-with-invalid-dynamic-range.pom
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.netflix.nebula</groupId>
+    <artifactId>my-module</artifactId>
+    <version>1.0.0</version>
+    <name>my-module</name>
+    <description>my-module description</description>
+    <url>https://github.com/nebula-plugins/my-module</url>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>netflixgithub</id>
+            <name>Netflix Open Source Development</name>
+            <email>netflixoss@netflix.com</email>
+        </developer>
+    </developers>
+    <scm>
+        <url>https://github.com/nebula-plugins/my-module.git</url>
+    </scm>
+    <dependencies>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.5.+</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <properties>
+        <nebula_Manifest_Version>1.0</nebula_Manifest_Version>
+        <nebula_Implementation_Title>com.netflix.nebula#my-module;1.0.0</nebula_Implementation_Title>
+        <nebula_Implementation_Version>1.8.0</nebula_Implementation_Version>
+        <nebula_Built_Status>integration</nebula_Built_Status>
+        <nebula_Built_By>travis</nebula_Built_By>
+        <nebula_Built_OS>Linux</nebula_Built_OS>
+        <nebula_Build_Date>2019-11-21_21:30:10</nebula_Build_Date>
+        <nebula_Gradle_Version>5.6.2</nebula_Gradle_Version>
+        <nebula_Module_Owner>netflixoss@netflix.com</nebula_Module_Owner>
+        <nebula_Module_Email>netflixoss@netflix.com</nebula_Module_Email>
+        <nebula_Module_Origin>https://github.com/nebula-plugins/my-module.git</nebula_Module_Origin>
+        <nebula_Change>b5e55af</nebula_Change>
+        <nebula_Branch>b5e55af8921fa1abe3345ca09c7acaefd8b50968</nebula_Branch>
+        <nebula_Build_Host>travis-job-3fcfc919-7e06-4960-98cb-a538a09f08c3</nebula_Build_Host>
+        <nebula_Build_Job>nebula-plugins/my-module</nebula_Build_Job>
+        <nebula_Build_Number>23</nebula_Build_Number>
+        <nebula_Build_Id>615268376</nebula_Build_Id>
+        <nebula_Created_By>1.8.0_222-8u222-b10-1ubuntu1~16.04.1-b10 (Private Build)</nebula_Created_By>
+        <nebula_Build_Java_Version>1.8.0_222</nebula_Build_Java_Version>
+        <nebula_X_Compile_Target_JDK>1.8</nebula_X_Compile_Target_JDK>
+        <nebula_X_Compile_Source_JDK>1.8</nebula_X_Compile_Source_JDK>
+    </properties>
+</project>

--- a/src/test/resources/my-module-with-invalid-license.pom
+++ b/src/test/resources/my-module-with-invalid-license.pom
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.netflix.nebula</groupId>
+    <artifactId>my-module</artifactId>
+    <version>1.0.0</version>
+    <name>my-module</name>
+    <description>my-module description</description>
+    <url>https://github.com/nebula-plugins/my-module</url>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>netflixgithub</id>
+            <name>Netflix Open Source Development</name>
+            <email>netflixoss@netflix.com</email>
+        </developer>
+    </developers>
+    <scm>
+        <url>https://github.com/nebula-plugins/my-module.git</url>
+    </scm>
+    <dependencies>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.5.7</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <properties>
+        <nebula_Manifest_Version>1.0</nebula_Manifest_Version>
+        <nebula_Implementation_Title>com.netflix.nebula#my-module;1.0.0</nebula_Implementation_Title>
+        <nebula_Implementation_Version>1.8.0</nebula_Implementation_Version>
+        <nebula_Built_Status>integration</nebula_Built_Status>
+        <nebula_Built_By>travis</nebula_Built_By>
+        <nebula_Built_OS>Linux</nebula_Built_OS>
+        <nebula_Build_Date>2019-11-21_21:30:10</nebula_Build_Date>
+        <nebula_Gradle_Version>5.6.2</nebula_Gradle_Version>
+        <nebula_Module_Owner>netflixoss@netflix.com</nebula_Module_Owner>
+        <nebula_Module_Email>netflixoss@netflix.com</nebula_Module_Email>
+        <nebula_Module_Origin>https://github.com/nebula-plugins/my-module.git</nebula_Module_Origin>
+        <nebula_Change>b5e55af</nebula_Change>
+        <nebula_Branch>b5e55af8921fa1abe3345ca09c7acaefd8b50968</nebula_Branch>
+        <nebula_Build_Host>travis-job-3fcfc919-7e06-4960-98cb-a538a09f08c3</nebula_Build_Host>
+        <nebula_Build_Job>nebula-plugins/my-module</nebula_Build_Job>
+        <nebula_Build_Number>23</nebula_Build_Number>
+        <nebula_Build_Id>615268376</nebula_Build_Id>
+        <nebula_Created_By>1.8.0_222-8u222-b10-1ubuntu1~16.04.1-b10 (Private Build)</nebula_Created_By>
+        <nebula_Build_Java_Version>1.8.0_222</nebula_Build_Java_Version>
+        <nebula_X_Compile_Target_JDK>1.8</nebula_X_Compile_Target_JDK>
+        <nebula_X_Compile_Source_JDK>1.8</nebula_X_Compile_Source_JDK>
+    </properties>
+</project>

--- a/src/test/resources/my-module-with-invalid-metadata.pom
+++ b/src/test/resources/my-module-with-invalid-metadata.pom
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId></groupId>
+    <artifactId></artifactId>
+    <version></version>
+    <name></name>
+    <description></description>
+    <url></url>
+    <dependencies>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.5.7</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <properties>
+        <nebula_Manifest_Version>1.0</nebula_Manifest_Version>
+        <nebula_Implementation_Title>com.netflix.nebula#my-module;1.0.0</nebula_Implementation_Title>
+        <nebula_Implementation_Version>1.8.0</nebula_Implementation_Version>
+        <nebula_Built_Status>integration</nebula_Built_Status>
+        <nebula_Built_By>travis</nebula_Built_By>
+        <nebula_Built_OS>Linux</nebula_Built_OS>
+        <nebula_Build_Date>2019-11-21_21:30:10</nebula_Build_Date>
+        <nebula_Gradle_Version>5.6.2</nebula_Gradle_Version>
+        <nebula_Module_Owner>netflixoss@netflix.com</nebula_Module_Owner>
+        <nebula_Module_Email>netflixoss@netflix.com</nebula_Module_Email>
+        <nebula_Module_Origin>https://github.com/nebula-plugins/my-module.git</nebula_Module_Origin>
+        <nebula_Change>b5e55af</nebula_Change>
+        <nebula_Branch>b5e55af8921fa1abe3345ca09c7acaefd8b50968</nebula_Branch>
+        <nebula_Build_Host>travis-job-3fcfc919-7e06-4960-98cb-a538a09f08c3</nebula_Build_Host>
+        <nebula_Build_Job>nebula-plugins/my-module</nebula_Build_Job>
+        <nebula_Build_Number>23</nebula_Build_Number>
+        <nebula_Build_Id>615268376</nebula_Build_Id>
+        <nebula_Created_By>1.8.0_222-8u222-b10-1ubuntu1~16.04.1-b10 (Private Build)</nebula_Created_By>
+        <nebula_Build_Java_Version>1.8.0_222</nebula_Build_Java_Version>
+        <nebula_X_Compile_Target_JDK>1.8</nebula_X_Compile_Target_JDK>
+        <nebula_X_Compile_Source_JDK>1.8</nebula_X_Compile_Source_JDK>
+    </properties>
+</project>

--- a/src/test/resources/my-module.pom
+++ b/src/test/resources/my-module.pom
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.netflix.nebula</groupId>
+    <artifactId>my-module</artifactId>
+    <version>1.0.0</version>
+    <name>my-module</name>
+    <description>my-module description</description>
+    <url>https://github.com/nebula-plugins/my-module</url>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>netflixgithub</id>
+            <name>Netflix Open Source Development</name>
+            <email>netflixoss@netflix.com</email>
+        </developer>
+    </developers>
+    <scm>
+        <url>https://github.com/nebula-plugins/my-module.git</url>
+    </scm>
+    <dependencies>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.5.7</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <properties>
+        <nebula_Manifest_Version>1.0</nebula_Manifest_Version>
+        <nebula_Implementation_Title>com.netflix.nebula#my-module;1.0.0</nebula_Implementation_Title>
+        <nebula_Implementation_Version>1.8.0</nebula_Implementation_Version>
+        <nebula_Built_Status>integration</nebula_Built_Status>
+        <nebula_Built_By>travis</nebula_Built_By>
+        <nebula_Built_OS>Linux</nebula_Built_OS>
+        <nebula_Build_Date>2019-11-21_21:30:10</nebula_Build_Date>
+        <nebula_Gradle_Version>5.6.2</nebula_Gradle_Version>
+        <nebula_Module_Owner>netflixoss@netflix.com</nebula_Module_Owner>
+        <nebula_Module_Email>netflixoss@netflix.com</nebula_Module_Email>
+        <nebula_Module_Origin>https://github.com/nebula-plugins/my-module.git</nebula_Module_Origin>
+        <nebula_Change>b5e55af</nebula_Change>
+        <nebula_Branch>b5e55af8921fa1abe3345ca09c7acaefd8b50968</nebula_Branch>
+        <nebula_Build_Host>travis-job-3fcfc919-7e06-4960-98cb-a538a09f08c3</nebula_Build_Host>
+        <nebula_Build_Job>nebula-plugins/my-module</nebula_Build_Job>
+        <nebula_Build_Number>23</nebula_Build_Number>
+        <nebula_Build_Id>615268376</nebula_Build_Id>
+        <nebula_Created_By>1.8.0_222-8u222-b10-1ubuntu1~16.04.1-b10 (Private Build)</nebula_Created_By>
+        <nebula_Build_Java_Version>1.8.0_222</nebula_Build_Java_Version>
+        <nebula_X_Compile_Target_JDK>1.8</nebula_X_Compile_Target_JDK>
+        <nebula_X_Compile_Source_JDK>1.8</nebula_X_Compile_Source_JDK>
+    </properties>
+</project>


### PR DESCRIPTION
We faced an issue with dgs framework when publishing to Maven Central:

```
Invalid POM: /com/netflix/graphql/dgs/graphql-dgs-platform/3.10.0/graphql-dgs-platform-3.10.0.pom: Invalid version for Dependency {groupId=com.jayway.jsonpath, artifactId=json-path, version=2.5.+, type=jar} - uses invalid dynamic version syntax. Replace with a fixed version or standard mathematical notation e.g., [1.5,) for version 1.5 and higher. Invalid version for Dependency {groupId=io.reactivex.rxjava3, artifactId=rxjava, version=3.0.+, type=jar} - uses invalid dynamic version syntax. Replace with a fixed version or standard mathematical notation e.g., [1.5,) for version 1.5 and higher. Invalid version for Dependency {groupId=io.projectreactor, artifactId=reactor-core, version=3.4.+, type=jar} - uses invalid dynamic version syntax. Replace with a fixed version or standard mathematical notation e.g., [1.5,) for version 1.5 and higher. Invalid version for Dependency {groupId=io.projectreactor, artifactId=reactor-test, version=3.4.+, type=jar} - uses invalid dynamic version syntax. Replace with a fixed version or standard mathematical notation e.g., [1.5,) for version 1.5 and higher.```
``` 

This is difficult to catch for engineers as this is not surfaced from Sonatype's API and accessing the UI becomes painful.

This addition to the plugin validates the POM files to make sure that we don't have dynamic ranges such as `2.+`. In addition, will check for things provided by netflixoss.nebula plugin: developers, scm, description, licenses.

Error messages are friendly enough to provide context on what to do or where to go. Example:

```
* What went wrong:
Execution failed for task ':verifyNebulaPublicationPomForMavenCentral'.
> nebula.plugin.publishing.pom.MavenCentralPomVerificationException: POM verification for Maven Central failed.
   POM contains the following errors:
  <developers> are required. Please add this information using gradle-contacts-plugin (https://github.com/nebula-plugins/gradle-contacts-plugin)

```

Also, made sure that the verification runs before publishing:

```
:list:build SKIPPED
:list:generatePomFileForNebulaPublication SKIPPED
:list:verifyNebulaPublicationPomForMavenCentral SKIPPED
:utilities:writeLicenseHeader SKIPPED
:utilities:licenseMain SKIPPED
:utilities:licenseTest SKIPPED
:utilities:license SKIPPED
:utilities:compileTestJava SKIPPED
:utilities:processTestResources SKIPPED
:utilities:testClasses SKIPPED
:utilities:test SKIPPED
:utilities:check SKIPPED
:utilities:build SKIPPED
:utilities:generatePomFileForNebulaPublication SKIPPED
:utilities:verifyNebulaPublicationPomForMavenCentral SKIPPED
:release SKIPPED
:initializeSonatypeStagingRepository SKIPPED
:app:generateMetadataFileForNebulaPublication SKIPPED
:app:sourceJar SKIPPED
:app:publishNebulaPublicationToSonatypeRepository SKIPPED
:list:generateMetadataFileForNebulaPublication SKIPPED
:list:sourceJar SKIPPED
:list:publishNebulaPublicationToSonatypeRepository SKIPPED
:utilities:generateMetadataFileForNebulaPublication SKIPPED
:utilities:sourceJar SKIPPED
:utilities:publishNebulaPublicationToSonatypeRepository SKIPPED
:closeSonatypeStagingRepository SKIPPED
:releaseSonatypeStagingRepository SKIPPED
:closeAndReleaseSonatypeStagingRepository SKIPPED
:postRelease SKIPPED
:final SKIPPED

```

This could be replaced in the future with something like https://github.com/gradle/gradle/issues/10969. In addition, we might want to ask Gradle to look at the verification as something that should happen across all projects so we don't have partial publishes and avoid requiring to wire those things ourselves