### PR TITLE
Update Gradle wrapper to 8.12-rc-2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-rc-2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionSha256Sum=4d9d7ad4cf8842f279649213d2f87d8f7e9a03ae75ac4389517aa574b1404b2a
+distributionSha256Sum=4c403eac4e3957107a6e954ae2b59ba6cf9823f683276f1f9e20ef79b8d350a2


### PR DESCRIPTION
Update Gradle wrapper to 8.12-rc-2

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.gradle.UpdateGradleWrapper?organizationId=ZmEzOTAwZTUtNjc2Yi00YmFlLTkwYTgtMGE2N2YzNzljYWQw#defaults=W3sibmFtZSI6InZlcnNpb24iLCJ2YWx1ZSI6IjguMTItcmMtMiJ9LHsibmFtZSI6ImRpc3RyaWJ1dGlvbiIsInZhbHVlIjoiYmluIn0seyJuYW1lIjoiYWRkSWZNaXNzaW5nIiwidmFsdWUiOiJGYWxzZSJ9XQ==